### PR TITLE
Improve handling of keywords in schema plugin

### DIFF
--- a/plugins/recipe_schema.py
+++ b/plugins/recipe_schema.py
@@ -21,7 +21,10 @@ def extract(url, _):
 	if "recipeCuisine" in json_recipe:
 		tags.append(json_recipe["recipeCuisine"])
 	if "keywords" in json_recipe:
-		tags.extend(kw.strip() for kw in json_recipe["keywords"].split(','))
+		kw = json_recipe["keywords"]
+		if isinstance(kw, str):
+			kw = kw.split(',')
+		append_or_extend(tags, kw)
 
 	description_parts = []
 	if "description" in json_recipe:


### PR DESCRIPTION
Some sites (notably chefkoch) serve keywords as a list instead of a comma separated string. With this fix we can handle both variants.

This sort of fixes #5 by making the chefkoch plugin obsolete.