### PR TITLE
Error handling

### DIFF
--- a/recipemd_extract/main.py
+++ b/recipemd_extract/main.py
@@ -21,6 +21,7 @@ def extract(url, debug=False):
 	soup = BeautifulSoup(page.text, "html5lib")
 
 	pluginFilelist=os.listdir(os.path.dirname(os.path.realpath(__file__))+'/plugins')
+	errors = []
 
 	for pluginFile in pluginFilelist:
 		if(pluginFile.endswith('.py') and pluginFile != "__init__.py"):
@@ -34,7 +35,9 @@ def extract(url, debug=False):
 			except Exception as e:
 				if debug:
 					raise e
-				print('In plugin "',pluginName,'": Error parsing recipe:',e, file=sys.stderr)
+				else:
+					errors.append('In plugin "' + pluginName + '": Error parsing recipe: ' + str(e))
+	return "\n".join(errors)
 
 def writeRecipe(recipe, file=None):
 	if not file:
@@ -59,6 +62,7 @@ def main():
 	if(recipe):
 		writeRecipe(recipe, file)
 	else:
+		print(recipe, file=sys.stderr)
 		print ('Could not extract recipe')
 
 

--- a/recipemd_extract/main.py
+++ b/recipemd_extract/main.py
@@ -40,12 +40,15 @@ def extract(url, debug=False):
 	return "\n".join(errors)
 
 def writeRecipe(recipe, file=None):
-	if not file:
+	if file:
+		filename = file.name
+	else:
 		joinedTitle = '_'.join(recipe.title.lower().split())
 		filename = ''.join(c for c in joinedTitle if (c.isalnum() or c in '._')) + '.md'
 		file = codecs.open(filename, 'w', encoding="utf-8")
 	with file:
 		file.write(RecipeSerializer().serialize(recipe))
+	return filename
 
 
 def main():
@@ -59,8 +62,9 @@ def main():
 
 	recipe=extract(url,args.debug)
 
-	if(recipe):
-		writeRecipe(recipe, file)
+	if isinstance(recipe,Recipe):
+		result = writeRecipe(recipe, file)
+		print('Recipe written to ' + result)
 	else:
 		print(recipe, file=sys.stderr)
 		print ('Could not extract recipe')


### PR DESCRIPTION
So I figured out what was going on in #14: The recipe was downloaded, but because the tool only printed an error
message, nothing else, I was very confused about what was going on.

This PR contains two commits/changes, both stand on their own if you want just one of them:

- The first prevents errors from being printed when a recipe could be downloaded (unless you're in debug mode).
- The second prints the recipe filename on success to make it easier to see that the tool succeeded.
